### PR TITLE
Update default commiter

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Commit and push if changed
         run: |-
           git diff
-          git config --global user.email "bot@github.com"
-          git config --global user.name "github-bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           git pull
           git add -A
           git commit -m "🤖 Auto update README" || exit 0


### PR DESCRIPTION
This PR updates the default author's information in github action workflow to avoid displaying a blank avatar.

Before
![image](https://user-images.githubusercontent.com/29560987/137177070-d737227c-438d-469f-bd6d-ff813e8535f1.png)
After
![image](https://user-images.githubusercontent.com/29560987/137177022-697537e6-97d5-4ae2-ac61-b490c119aca0.png)